### PR TITLE
Improve Loading Pokeball and Leaderboard Styling

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,4 +15,7 @@ Try to get the quickest time in all 3 levels!
 This project was originally written with JavaScript and CSS, then converted to TypeScript and SASS/SCSS.
 
 Additionally, it was originally deployed using Firebase, then converted to using an Express backend with MongoDB deployed on Render.
+
+The backend has since then been moved to a serverless backend running on AWS API Gateway, Lambda, and DynamoDB. The app is still hosted on Render.
+
 It can be found and played [here](https://waldo-frontend.onrender.com/).

--- a/src/components/LoadingPokeball/LoadingPokeball.tsx
+++ b/src/components/LoadingPokeball/LoadingPokeball.tsx
@@ -7,7 +7,7 @@ const LoadingPokeball = () => {
         alt="A minimalist rendition of the classic Pokeball,
         with red and white semicircles separated by a line that meets in the middle to form another circle."
       />
-      <h1>Loading...</h1>
+      <h1 className="loading-pokeball-message">Loading...</h1>
     </div>
   );
 };

--- a/src/styles/_leaderboard.scss
+++ b/src/styles/_leaderboard.scss
@@ -39,7 +39,7 @@
         th {
           border-bottom: solid 2px black;
           padding-right: 5px;
-          padding-bottom: 15px;
+          padding-bottom: 10px;
         }
 
         td {

--- a/src/styles/_multiElement.scss
+++ b/src/styles/_multiElement.scss
@@ -62,8 +62,8 @@ button:hover,
 }
 
 .loading-pokeball-container {
-  @include flex(flex-start, center, 0, column);
-  margin-top: 15vh;
+  @include flex(center, center, 0, column);
+  height: 100vh;
 }
 
 @keyframes pokeball-rotate {

--- a/src/styles/_multiElement.scss
+++ b/src/styles/_multiElement.scss
@@ -66,6 +66,12 @@ button:hover,
   height: 100vh;
 }
 
+.loading-pokeball-message {
+  background-color: rgba(255, 255, 255, 0.5);
+  padding: 4px 8px;
+  border-radius: 4px;
+}
+
 @keyframes pokeball-rotate {
   from {
     transform: rotate(0);

--- a/src/styles/_multiElement.scss
+++ b/src/styles/_multiElement.scss
@@ -81,5 +81,5 @@ button:hover,
   animation-iteration-count: infinite;
   animation-timing-function: linear;
   animation-fill-mode: forwards;
-  width: 40vw;
+  width: 35vw;
 }


### PR DESCRIPTION
The loading Pokeball previously did not take up the entire page, resulting in the background image being cropped. Additionally, the leaderboard headers took up too much space and looked off.